### PR TITLE
Networking reworkded with asyncio.Streams

### DIFF
--- a/src/client/client.py
+++ b/src/client/client.py
@@ -1,6 +1,5 @@
 # Client side
 
-from distutils.command.clean import clean
 import hashlib
 import asyncio
 import os
@@ -8,14 +7,12 @@ import re
 from pathlib import Path
 import uuid
 import tqdm
-import socket
 import pickle
 import getpass
 
 class Client:
     """Implementation of a Kryzbu client."""
 
-    BUFFER_SIZE = 4096
     SERVER_IP = "127.0.0.1"
     SERVER_PORT = 60606
     USER_CONF = Path('client/_data/config/user.conf')
@@ -51,7 +48,7 @@ class Client:
                 # Send file
                 with open(file_path, "rb") as f:
                     while True:
-                        bytes_read = f.read(Client.BUFFER_SIZE)
+                        bytes_read = f.read(1024)
                         if not bytes_read:
                             break
                         progress.update(len(bytes_read))
@@ -103,7 +100,7 @@ class Client:
             # Receive file
             with open(str(os.path.join(os.path.expanduser('~/Downloads'), file_name)), "wb") as f:
                 while True:
-                    bytes_read = await reader.read()
+                    bytes_read = await reader.read(1024)
                     if not bytes_read:
                         break
                     f.write(bytes_read)

--- a/src/kryzbu.py
+++ b/src/kryzbu.py
@@ -5,6 +5,8 @@
 # as a standard command-line tool from everywhere.
 
 import argparse
+import asyncio
+from multiprocessing.connection import Client
 from client import client
 
 client.Client.init()
@@ -23,21 +25,21 @@ args = parser.parse_args()
 if args.upload:
     # Upload file to a server
     for file in args.upload:
-        client.Client.upload(file)
+        asyncio.run(client.Client.upload(file))
 elif args.download:
     # Download file from server
     for file in args.download:
-        client.Client.download(file)
+        asyncio.run(client.Client.download(file))
 elif args.remove:
     # Remove file from server
     for file in args.remove:
-        client.Client.remove(file)
+        asyncio.run(client.Client.remove(file))
 elif args.list:
     # List available files on server
-    client.Client.list_files(False)
+    asyncio.run(client.Client.list_files(False))
 elif args.listall:
     # List available files on server including additional info
-    client.Client.list_files(True)
+    asyncio.run(client.Client.list_files(True))
 elif args.info:
     # List available files on server including additional info
     client.Client.info()

--- a/src/kryzbu_server.py
+++ b/src/kryzbu_server.py
@@ -30,5 +30,5 @@ elif args.list:
     User_db.show_all()
 else:
     print('[*] Kryzbu server starting...')
-    server.Server.run()
+    server.Server.start()
 

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -14,7 +14,6 @@ class Server:
     IP = "127.0.0.1"
     PORT = 60606
     EOM = '\n' # End of Message sign, should be same as in client.py
-    BUFFER_SIZE = 4096 # TODO: defined on two seperate places (in client.py as well)
     SERVER_FOLDER = Path("server/_data/files/") # Universal Path object for multi OS path declaration
 
 
@@ -138,7 +137,7 @@ class Server:
                 # Send file
                 with open(file_path, "rb") as f:
                     while True:
-                        bytes_read = f.read(Server.BUFFER_SIZE)
+                        bytes_read = f.read(1024)
                         if not bytes_read:
                             break
                         writer.write(bytes_read)


### PR DESCRIPTION
S touto implementací jež projekt nepoužívá low-level sockety ale používá abstraktnější Streamy postavené nad sokety. Takto je server schopen obsluhovat paralelně více uživatelů najednou.

pro čtení se používá objekt `reader` s funkci `readuntil(<separator>)` a pro osedesilani dat `writer` a funkci `write(<bytes>)`
Funkce `write()` dává bajty do buffru odkud si je sám os odešle jakmile to bude možné. Funkce samotná není asynchroní. Může se stát že buffer přeteče a nastane chyba. Proto by se občas, nebo při větších přenosech dat, měla po funkci `write()` zavolat `await writer.drain()`, který počká pokud je to nutné dokud se buffer neuvolní.

Testoval jsem to jen minimálně, už na to nemám síly. Takže by bylo fajn, ještě před přiřazením do mainu, to nechat ve své větvi a otestovat to. Zkusit jestli tomu jede funkcionalita co má a pokud né tak zadokumentovat co nejede, co to háže za errory, otevřít issues a pod. @Kaspis123. 

Chanlog:  
- Ted jsou to opravdu streamy, takže musel být přídán symbol, který bude odědělovat jednotlivé zprávy. Je to konstanta Client.EOM a Server.EOM (End Of Message). Nyní používáme '\n'. Funkce `read` čtě bajty až po zakončovací symbol včetně. Z toho vyplývá že je ho potřeba odstaňovat. Načtení zprávy a převedení do na str může vypadat následovně:
```
data = await reader.readuntil(Client.EOM.encode())
answer = data.decode()[:-1]   # Decode and strip EOM symbol
```
- Po požadavku na snažení neexistujícího souboru již nejsou vypsány dostupné soubory.